### PR TITLE
Fix paddle score calculation

### DIFF
--- a/src/utils/scoreCalculator.js
+++ b/src/utils/scoreCalculator.js
@@ -10,7 +10,7 @@ import { calculateGeographicProtection } from './coastlineAnalysis';
  * @returns { totalScore, breakdown: { wind, waves, swell, precipitation,
  *   temperature, cloudcover, geographic, tide, currents } }
  */
-export function calculatePaddleScore(beach, hours, range) {
+export async function calculatePaddleScore(beach, hours, range) {
   const slice = hours.slice(range.startIndex, range.endIndex + 1);
   const n     = slice.length;
   const avg   = key => slice.reduce((s, h) => s + (h[key] ?? 0), 0) / n;
@@ -19,6 +19,7 @@ export function calculatePaddleScore(beach, hours, range) {
   const windSpeed   = avg('windSpeed');
   const windDir     = avg('windDirection');
   const waveHeight  = avg('waveHeight');
+  const waveDir     = avg('waveDirection');
   const swellHeight = avg('swellHeight');
   const precip      = avg('precipitation');
   const temp        = avg('temperature');
@@ -27,8 +28,11 @@ export function calculatePaddleScore(beach, hours, range) {
   const currentSpd  = avg('currentSpeed');
 
   // Geographic protection
-  const { protectedWindSpeed, protectedWaveHeight } =
-    calculateGeographicProtection(beach, windDir, waveHeight);
+  const { windProtection, waveProtection } =
+    await calculateGeographicProtection(beach, windDir, waveDir);
+
+  const protectedWindSpeed  = windSpeed * (1 - (windProtection * 0.9));
+  const protectedWaveHeight = waveHeight * (1 - (waveProtection * 0.9));
 
   // Scoring buckets (max points in parentheses)
   const ptsWind   = linearScore(protectedWindSpeed, 0, 20) * 40;    // 40 pts


### PR DESCRIPTION
## Summary
- fix wave direction argument to protection calculator
- compute wind/wave protection adjustments and make calculatePaddleScore async

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fe9c040088322a800f8429662f5d6