### PR TITLE
Fix wave direction for protection

### DIFF
--- a/src/utils/scoreCalculator.js
+++ b/src/utils/scoreCalculator.js
@@ -18,6 +18,7 @@ export function calculatePaddleScore(beach, hours, range) {
   // Averages
   const windSpeed   = avg('windSpeed');
   const windDir     = avg('windDirection');
+  const waveDir     = avg('waveDirection');
   const waveHeight  = avg('waveHeight');
   const swellHeight = avg('swellHeight');
   const precip      = avg('precipitation');
@@ -28,7 +29,7 @@ export function calculatePaddleScore(beach, hours, range) {
 
   // Geographic protection
   const { protectedWindSpeed, protectedWaveHeight } =
-    calculateGeographicProtection(beach, windDir, waveHeight);
+    calculateGeographicProtection(beach, windDir, waveDir);
 
   // Scoring buckets (max points in parentheses)
   const ptsWind   = linearScore(protectedWindSpeed, 0, 20) * 40;    // 40 pts


### PR DESCRIPTION
## Summary
- use average wave direction in paddle score computation
- pass wave direction to `calculateGeographicProtection`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683ff0133a488322b501c7e8b2ffd9d6