### PR TITLE
Fix helpers import path for Vercel build

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { AlertCircle, Home, Map, MapPin, Plus, Trash2, ChevronLeft, HelpCircle } from "lucide-react";
 import { useBeachManager } from "./BeachManager";
 import FixedBeachView from "./FixedBeachView";
-import { ErrorBoundary, DeleteConfirmationModal } from "./helpers";
+import { ErrorBoundary, DeleteConfirmationModal } from "./helpers.jsx";
 import FAQ from "./FAQ"; // Import the new FAQ component
 
 const App = () => {

--- a/src/BeachManager.jsx
+++ b/src/BeachManager.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { analyzeBayProtection } from "./utils/coastlineAnalysis";
-import { parseGoogleMapsUrl } from "./helpers";
+import { parseGoogleMapsUrl } from "./helpers.jsx";
 import { resolveGoogleMapsShortUrl } from "./proxy";
-import { getCardinalDirection } from "./helpers";
+import { getCardinalDirection } from "./helpers.jsx";
 
 export const useBeachManager = () => {
   const [beaches, setBeaches] = useState([]);

--- a/src/FixedBeachView.jsx
+++ b/src/FixedBeachView.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { Home, ChevronLeft, RefreshCw, AlertCircle, MapPin, Map, Wind, Thermometer, Droplets, Waves, Sun, Clock, Calendar, Info } from "lucide-react";
 import { calculateGeographicProtection } from "./utils/coastlineAnalysis";
-import { getCardinalDirection } from "./helpers";
+import { getCardinalDirection } from "./helpers.jsx";
 
 const FixedBeachView = ({ 
   beach, 


### PR DESCRIPTION
## Summary
- update imports to use `helpers.jsx` extension

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684001906a888322a72ef81854de51e9