### PR TITLE
Integrate Google Maps parsing utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node src/helpers.test.js"
   },
   "dependencies": {
     "@turf/turf": "^6.5.0",

--- a/src/googleMapsUtils.js
+++ b/src/googleMapsUtils.js
@@ -1,0 +1,70 @@
+// Utilities for parsing Google Maps URLs without React
+
+// Helper function to try extracting location name from URL parameters
+const extractNameFromUrl = (url) => {
+  try {
+    // Try pattern: /place/Name/ in the URL
+    let placeMatch = url.match(/\/place\/([^\/]+)\//);
+    if (placeMatch && placeMatch[1]) {
+      const decoded = decodeURIComponent(placeMatch[1]);
+      // Clean up the name (replace + and remove coordinates)
+      return decoded
+        .replace(/\+/g, ' ')
+        .replace(/\d+\.\d+,\d+\.\d+/, '')
+        .trim();
+    }
+
+    // Try pattern: ?q=Name in the URL
+    let qMatch = url.match(/[?&]q=([^&@]+)/);
+    if (qMatch && qMatch[1]) {
+      const decoded = decodeURIComponent(qMatch[1]);
+      // Remove coordinates if present
+      return decoded
+        .replace(/\+/g, ' ')
+        .replace(/\d+\.\d+,\d+\.\d+/, '')
+        .trim();
+    }
+
+    return null;
+  } catch (e) {
+    console.error("Error extracting name from URL:", e);
+    return null;
+  }
+};
+
+// Parse Google Maps URL - standard pattern only, short URLs now handled by proxy.js
+export const parseGoogleMapsUrl = (url) => {
+  if (!url) return null;
+
+  // Extract name if it's in the URL
+  const nameFromUrl = extractNameFromUrl(url);
+
+  // Handle standard Google Maps URL with @lat,lng
+  let match = url.match(/@(-?\d+\.\d+),(-?\d+\.\d+)/);
+  if (match) {
+    return {
+      name: nameFromUrl || "New Beach",
+      latitude: parseFloat(match[1]),
+      longitude: parseFloat(match[2]),
+      googleMapsUrl: url
+    };
+  }
+
+  // Handle ?q=lat,lng format
+  match = url.match(/\?q=(-?\d+\.\d+),(-?\d+\.\d+)/);
+  if (match) {
+    return {
+      name: nameFromUrl || "New Beach",
+      latitude: parseFloat(match[1]),
+      longitude: parseFloat(match[2]),
+      googleMapsUrl: url
+    };
+  }
+
+  // If it's a short URL, return null to let the proxy handler take over
+  if (url.includes("goo.gl")) {
+    return null;
+  }
+
+  return null;
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { ArrowLeft, ArrowRight, AlertCircle } from "lucide-react";
+import { parseGoogleMapsUrl } from "./googleMapsUtils.js";
+
+export { parseGoogleMapsUrl };
 
 /* eslint react-refresh/only-export-components: off */
 
@@ -10,109 +13,6 @@ export const getCardinalDirection = (degrees) => {
   return directions[(val % 16)];
 };
 
-// Helper function to try extracting location name from URL parameters
-const extractNameFromUrl = (url) => {
-  try {
-    // Try pattern: /place/Name/ in the URL
-    let placeMatch = url.match(/\/place\/([^\/]+)\//);
-    if (placeMatch && placeMatch[1]) {
-      const decoded = decodeURIComponent(placeMatch[1]);
-      // Clean up the name (replace + and remove coordinates)
-      return decoded
-        .replace(/\+/g, ' ')
-        .replace(/\d+\.\d+,\d+\.\d+/, '')
-        .trim();
-    }
-    
-    // Try pattern: ?q=Name in the URL
-    let qMatch = url.match(/[?&]q=([^&@]+)/);
-    if (qMatch && qMatch[1]) {
-      const decoded = decodeURIComponent(qMatch[1]);
-      // Remove coordinates if present
-      return decoded
-        .replace(/\+/g, ' ')
-        .replace(/\d+\.\d+,\d+\.\d+/, '')
-        .trim();
-    }
-    
-    return null;
-  } catch (e) {
-    console.error("Error extracting name from URL:", e);
-    return null;
-  }
-};
-
-// Helper function to try extracting location from URL parameters
-const extractLocationFromUrl = (url) => {
-  try {
-    // Try to find lat,lng pattern
-    const latLngMatch = url.match(/[?&]q=(-?\d+\.\d+),(-?\d+\.\d+)/);
-    if (latLngMatch) {
-      return {
-        lat: parseFloat(latLngMatch[1]),
-        lng: parseFloat(latLngMatch[2])
-      };
-    }
-    
-    // Try to find @lat,lng pattern
-    const atLatLngMatch = url.match(/@(-?\d+\.\d+),(-?\d+\.\d+)/);
-    if (atLatLngMatch) {
-      return {
-        lat: parseFloat(atLatLngMatch[1]),
-        lng: parseFloat(atLatLngMatch[2])
-      };
-    }
-    
-    return null;
-  } catch (e) {
-    console.error("Error extracting location from URL:", e);
-    return null;
-  }
-};
-
-// Parse Google Maps URL - standard pattern only, short URLs now handled by proxy.js
-export const parseGoogleMapsUrl = (url) => {
-  if (!url) return null;
-  
-  console.log("Parsing URL:", url);
-  
-  // Extract name if it's in the URL
-  const nameFromUrl = extractNameFromUrl(url);
-  console.log("Name extracted from URL:", nameFromUrl);
-  
-  // Handle standard Google Maps URL with @lat,lng
-  let match = url.match(/@(-?\d+\.\d+),(-?\d+\.\d+)/);
-  if (match) {
-    console.log("Coordinates extracted from URL:", match[1], match[2]);
-    return {
-      name: nameFromUrl || "New Beach",
-      latitude: parseFloat(match[1]),
-      longitude: parseFloat(match[2]),
-      googleMapsUrl: url
-    };
-  }
-  
-  // Handle ?q=lat,lng format
-  match = url.match(/\?q=(-?\d+\.\d+),(-?\d+\.\d+)/);
-  if (match) {
-    console.log("Coordinates extracted from q= parameter:", match[1], match[2]);
-    return {
-      name: nameFromUrl || "New Beach",
-      latitude: parseFloat(match[1]),
-      longitude: parseFloat(match[2]),
-      googleMapsUrl: url
-    };
-  }
-  
-  // If it's a short URL, return null to let the proxy handler take over
-  if (url.includes("goo.gl")) {
-    console.log("Short URL detected, deferring to proxy handler");
-    return null;
-  }
-  
-  console.log("No matching pattern found");
-  return null;
-};
 
 // Error Boundary Component
 export const ErrorBoundary = ({ children }) => {

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { parseGoogleMapsUrl } from './googleMapsUtils.js';
+
+// test 1: q=lat,lng pattern
+const result1 = parseGoogleMapsUrl('https://maps.google.com/?q=37.8235,23.7761');
+assert.equal(result1.latitude, 37.8235);
+assert.equal(result1.longitude, 23.7761);
+console.log('Test 1 passed');
+
+// test 2: @lat,lng pattern
+const result2 = parseGoogleMapsUrl('https://maps.google.com/@37.8235,23.7761,15z');
+assert.equal(result2.latitude, 37.8235);
+assert.equal(result2.longitude, 23.7761);
+console.log('Test 2 passed');


### PR DESCRIPTION
## Summary
- add script `test` to run node-based tests
- split out URL parsing logic to `googleMapsUtils.js`
- rename `helpers.jsx` to `helpers.js` and reexport parser
- create `helpers.test.js` for lightweight tests

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684003e862fc8322b117f9bd95728c48