### PR TITLE
Fix build by renaming helpers file

### DIFF
--- a/src/helpers.jsx
+++ b/src/helpers.jsx
@@ -122,7 +122,6 @@ export const DatePickerModal = ({ currentDate = new Date(), onSelect, onClose })
   
   // Add the days of the month
   for (let day = 1; day <= daysInMonth; day++) {
-    const date = new Date(year, month, day);
     const isSelected = 
       selectedDate.getDate() === day &&
       selectedDate.getMonth() === month &&


### PR DESCRIPTION
## Summary
- rename `helpers.js` to `helpers.jsx` so Vite treats JSX code correctly
- remove unused variable in `helpers.jsx`

## Testing
- `npm run test`
- `npm run lint` *(fails: no-unused-vars in other files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840085662a88322baac02bf323154c8