### PR TITLE
Improve score breakdown display

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ To create a production build:
 npm run build
 ```
 
+The built files appear in the `dist/` directory. Run `npm run preview` to test
+the production build locally and redeploy the contents of `dist` to update the
+live site.
+
 ## About the data
 
 Weather and marine forecasts are provided by Open‑Meteo. Geographic protection calculations rely on coastline and island data processed from GADM datasets. Always verify local conditions before heading out.

--- a/src/FixedBeachView.jsx
+++ b/src/FixedBeachView.jsx
@@ -145,7 +145,7 @@ const FixedBeachView = ({
         temperature: { value: avgTemp, score: 0, maxPossible: 10 },
         cloudCover: { value: avgCloud, score: 0, maxPossible: 10 },
         geoProtection: { value: protection.protectionScore, score: 0, maxPossible: 15 },
-        total: { score: 0, maxPossible: 100 }
+        total: { score: 0, rawScore: 0, bonus: 0, maxPossible: 100 }
       };
       
       // Calculate individual scores
@@ -197,6 +197,8 @@ const FixedBeachView = ({
       breakdown.temperature.score = Math.round(breakdown.temperature.score);
       breakdown.cloudCover.score = Math.round(breakdown.cloudCover.score);
       breakdown.geoProtection.score = Math.round(breakdown.geoProtection.score);
+      breakdown.total.rawScore = Math.round(totalScore);
+      breakdown.total.bonus = Math.max(0, breakdown.total.rawScore - 100);
       breakdown.total.score = Math.round(Math.min(100, totalScore));
       
       // Apply special conditions
@@ -534,18 +536,34 @@ const FixedBeachView = ({
                 </td>
               </tr>
               <tr className="bg-blue-50">
-                <td className="px-4 py-3 whitespace-nowrap text-sm font-bold text-gray-900">TOTAL SCORE</td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm font-bold text-gray-900">
+                  TOTAL SCORE
+                </td>
                 <td className="px-4 py-3 whitespace-nowrap"></td>
                 <td className={`px-4 py-3 whitespace-nowrap text-sm font-bold text-right ${
-                  scoreBreakdown.total.score >= 85 ? 'text-green-600' : 
+                  scoreBreakdown.total.score >= 85 ? 'text-green-600' :
                   scoreBreakdown.total.score >= 70 ? 'text-yellow-600' :
                   scoreBreakdown.total.score >= 50 ? 'text-orange-600' : 'text-red-600'
                 }`}>
                   {scoreBreakdown.total.score}/{scoreBreakdown.total.maxPossible}
                 </td>
               </tr>
+              {scoreBreakdown.total.rawScore > scoreBreakdown.total.maxPossible && (
+                <tr className="bg-blue-50">
+                  <td className="px-4 py-1 whitespace-nowrap text-xs text-gray-600">
+                    Raw Score (with bonus)
+                  </td>
+                  <td className="px-4 py-1 whitespace-nowrap"></td>
+                  <td className="px-4 py-1 whitespace-nowrap text-xs text-right text-gray-600">
+                    {scoreBreakdown.total.rawScore}
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
+          <p className="text-xs text-gray-500 mt-2 px-4">
+            The final score is capped at 100. When geographic protection adds bonus points, the raw total is shown below.
+          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- show raw score with bonus as a separate row
- clarify cap note
- document how to preview the production build

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842c571d7e48322bc1c6c41f4ad3955