### PR TITLE
Fix wind direction averaging and await protection

### DIFF
--- a/src/FixedBeachView.jsx
+++ b/src/FixedBeachView.jsx
@@ -119,8 +119,15 @@ const FixedBeachView = ({
       
       const maxPrecip = Math.max(...relevantIndices.map(i => weather.hourly.precipitation[i]));
       
-      const avgWindDir = relevantIndices.map(i => weather.hourly.winddirection_10m[i])
-        .reduce((sum, val) => sum + val, 0) / relevantIndices.length;
+      // Average wind direction using vector mean to handle circular data
+      let sinSum = 0;
+      let cosSum = 0;
+      relevantIndices.forEach(i => {
+        const rad = weather.hourly.winddirection_10m[i] * Math.PI / 180;
+        sinSum += Math.sin(rad);
+        cosSum += Math.cos(rad);
+      });
+      const avgWindDir = (Math.atan2(sinSum / relevantIndices.length, cosSum / relevantIndices.length) * 180 / Math.PI + 360) % 360;
       
       // Get wave data from daily or calculate from hourly
       const waveHeight = marine.daily.wave_height_max[0];

--- a/src/utils/scoreCalculator.js
+++ b/src/utils/scoreCalculator.js
@@ -10,7 +10,7 @@ import { calculateGeographicProtection } from './coastlineAnalysis';
  * @returns { totalScore, breakdown: { wind, waves, swell, precipitation,
  *   temperature, cloudcover, geographic, tide, currents } }
  */
-export function calculatePaddleScore(beach, hours, range) {
+export async function calculatePaddleScore(beach, hours, range) {
   const slice = hours.slice(range.startIndex, range.endIndex + 1);
   const n     = slice.length;
   const avg   = key => slice.reduce((s, h) => s + (h[key] ?? 0), 0) / n;
@@ -27,7 +27,7 @@ export function calculatePaddleScore(beach, hours, range) {
 
   // Geographic protection
   const { protectedWindSpeed, protectedWaveHeight } =
-    calculateGeographicProtection(beach, windDir, waveDir);
+    await calculateGeographicProtection(beach, windDir, waveDir);
 
   // Scoring buckets (max points in parentheses)
   const ptsWind   = linearScore(protectedWindSpeed, 0, 20) * 40;    // 40 pts


### PR DESCRIPTION
## Summary
- compute average wind direction with a vector-based mean
- await the geographic protection function in the alternative score calculator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842d72d29dc8322a574843c95a65543