### PR TITLE
Improve clarity of paddle score breakdown

### DIFF
--- a/src/FixedBeachView.jsx
+++ b/src/FixedBeachView.jsx
@@ -454,14 +454,28 @@ const FixedBeachView = ({
   // Render score breakdown
   const renderScoreBreakdown = () => {
     if (!scoreBreakdown) return null;
-    
+
+    const Progress = ({ score, max, color }) => (
+      <div className="w-24 bg-gray-200 h-2 rounded mt-1 overflow-hidden">
+        <div
+          className={`${color} h-2 rounded`}
+          style={{ width: `${Math.min(100, (score / max) * 100)}%` }}
+        ></div>
+      </div>
+    );
+
     return (
       <div className="bg-white p-5 rounded-lg mt-4 shadow-sm border">
         <h4 className="font-medium mb-4 flex items-center text-gray-800">
           <Info className="h-5 w-5 mr-2 text-blue-600" />
           Score Breakdown
         </h4>
-        
+
+        <p className="text-sm text-gray-600 mb-3">
+          Each factor adds points toward the final paddle score. The progress bar shows
+          how close it is to its maximum value.
+        </p>
+
         <div className="overflow-x-auto rounded-lg border border-gray-200">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
@@ -475,16 +489,28 @@ const FixedBeachView = ({
               <tr>
                 <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-gray-700">Wind Speed</td>
                 <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500 text-right">
-                  {scoreBreakdown.windSpeed.raw.toFixed(1)} km/h 
+                  {scoreBreakdown.windSpeed.raw.toFixed(1)} km/h
                   <span className="text-xs text-gray-400 ml-1">
                     (Protected: {scoreBreakdown.windSpeed.protected.toFixed(1)})
                   </span>
                 </td>
-                <td className={`px-4 py-2 whitespace-nowrap text-sm font-medium text-right ${
-                  scoreBreakdown.windSpeed.score > 30 ? 'text-green-600' : 
-                  scoreBreakdown.windSpeed.score > 20 ? 'text-yellow-600' : 'text-red-600'
-                }`}>
-                  {scoreBreakdown.windSpeed.score}/{scoreBreakdown.windSpeed.maxPossible}
+                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.windSpeed.score > 30 ? 'text-green-600' :
+                    scoreBreakdown.windSpeed.score > 20 ? 'text-yellow-600' : 'text-red-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.windSpeed.score}/{scoreBreakdown.windSpeed.maxPossible}
+                    </span>
+                    <Progress
+                      score={scoreBreakdown.windSpeed.score}
+                      max={scoreBreakdown.windSpeed.maxPossible}
+                      color={
+                        scoreBreakdown.windSpeed.score > 30 ? 'bg-green-500' :
+                        scoreBreakdown.windSpeed.score > 20 ? 'bg-yellow-500' : 'bg-red-500'
+                      }
+                    />
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -495,11 +521,23 @@ const FixedBeachView = ({
                     (Protected: {scoreBreakdown.waveHeight.protected.toFixed(2)})
                   </span>
                 </td>
-                <td className={`px-4 py-2 whitespace-nowrap text-sm font-medium text-right ${
-                  scoreBreakdown.waveHeight.score > 15 ? 'text-green-600' : 
-                  scoreBreakdown.waveHeight.score > 10 ? 'text-yellow-600' : 'text-red-600'
-                }`}>
-                  {scoreBreakdown.waveHeight.score}/{scoreBreakdown.waveHeight.maxPossible}
+                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.waveHeight.score > 15 ? 'text-green-600' :
+                    scoreBreakdown.waveHeight.score > 10 ? 'text-yellow-600' : 'text-red-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.waveHeight.score}/{scoreBreakdown.waveHeight.maxPossible}
+                    </span>
+                    <Progress
+                      score={scoreBreakdown.waveHeight.score}
+                      max={scoreBreakdown.waveHeight.maxPossible}
+                      color={
+                        scoreBreakdown.waveHeight.score > 15 ? 'bg-green-500' :
+                        scoreBreakdown.waveHeight.score > 10 ? 'bg-yellow-500' : 'bg-red-500'
+                      }
+                    />
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -507,11 +545,23 @@ const FixedBeachView = ({
                 <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500 text-right">
                   {scoreBreakdown.swellHeight.raw.toFixed(2)} m
                 </td>
-                <td className={`px-4 py-2 whitespace-nowrap text-sm font-medium text-right ${
-                  scoreBreakdown.swellHeight.score > 7 ? 'text-green-600' : 
-                  scoreBreakdown.swellHeight.score > 5 ? 'text-yellow-600' : 'text-red-600'
-                }`}>
-                  {scoreBreakdown.swellHeight.score}/{scoreBreakdown.swellHeight.maxPossible}
+                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.swellHeight.score > 7 ? 'text-green-600' :
+                    scoreBreakdown.swellHeight.score > 5 ? 'text-yellow-600' : 'text-red-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.swellHeight.score}/{scoreBreakdown.swellHeight.maxPossible}
+                    </span>
+                    <Progress
+                      score={scoreBreakdown.swellHeight.score}
+                      max={scoreBreakdown.swellHeight.maxPossible}
+                      color={
+                        scoreBreakdown.swellHeight.score > 7 ? 'bg-green-500' :
+                        scoreBreakdown.swellHeight.score > 5 ? 'bg-yellow-500' : 'bg-red-500'
+                      }
+                    />
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -519,10 +569,19 @@ const FixedBeachView = ({
                 <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500 text-right">
                   {scoreBreakdown.precipitation.value.toFixed(1)} mm
                 </td>
-                <td className={`px-4 py-2 whitespace-nowrap text-sm font-medium text-right ${
-                  scoreBreakdown.precipitation.value < 1 ? 'text-green-600' : 'text-red-600'
-                }`}>
-                  {scoreBreakdown.precipitation.score}/{scoreBreakdown.precipitation.maxPossible}
+                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.precipitation.value < 1 ? 'text-green-600' : 'text-red-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.precipitation.score}/{scoreBreakdown.precipitation.maxPossible}
+                    </span>
+                    <Progress
+                      score={scoreBreakdown.precipitation.score}
+                      max={scoreBreakdown.precipitation.maxPossible}
+                      color={scoreBreakdown.precipitation.value < 1 ? 'bg-green-500' : 'bg-red-500'}
+                    />
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -530,10 +589,19 @@ const FixedBeachView = ({
                 <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500 text-right">
                   {scoreBreakdown.temperature.value.toFixed(1)} °C
                 </td>
-                <td className={`px-4 py-2 whitespace-nowrap text-sm font-medium text-right ${
-                  scoreBreakdown.temperature.score > 7 ? 'text-green-600' : 'text-yellow-600'
-                }`}>
-                  {scoreBreakdown.temperature.score}/{scoreBreakdown.temperature.maxPossible}
+                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.temperature.score > 7 ? 'text-green-600' : 'text-yellow-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.temperature.score}/{scoreBreakdown.temperature.maxPossible}
+                    </span>
+                    <Progress
+                      score={scoreBreakdown.temperature.score}
+                      max={scoreBreakdown.temperature.maxPossible}
+                      color={scoreBreakdown.temperature.score > 7 ? 'bg-green-500' : 'bg-yellow-500'}
+                    />
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -541,11 +609,23 @@ const FixedBeachView = ({
                 <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500 text-right">
                   {scoreBreakdown.cloudCover.value.toFixed(0)}%
                 </td>
-                <td className={`px-4 py-2 whitespace-nowrap text-sm font-medium text-right ${
-                  scoreBreakdown.cloudCover.score > 7 ? 'text-green-600' : 
-                  scoreBreakdown.cloudCover.score > 5 ? 'text-yellow-600' : 'text-gray-600'
-                }`}>
-                  {scoreBreakdown.cloudCover.score}/{scoreBreakdown.cloudCover.maxPossible}
+                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.cloudCover.score > 7 ? 'text-green-600' :
+                    scoreBreakdown.cloudCover.score > 5 ? 'text-yellow-600' : 'text-gray-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.cloudCover.score}/{scoreBreakdown.cloudCover.maxPossible}
+                    </span>
+                    <Progress
+                      score={scoreBreakdown.cloudCover.score}
+                      max={scoreBreakdown.cloudCover.maxPossible}
+                      color={
+                        scoreBreakdown.cloudCover.score > 7 ? 'bg-green-500' :
+                        scoreBreakdown.cloudCover.score > 5 ? 'bg-yellow-500' : 'bg-gray-400'
+                      }
+                    />
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -553,11 +633,23 @@ const FixedBeachView = ({
                 <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500 text-right">
                   {scoreBreakdown.geoProtection.value.toFixed(0)}/100
                 </td>
-                <td className={`px-4 py-2 whitespace-nowrap text-sm font-medium text-right ${
-                  scoreBreakdown.geoProtection.score > 10 ? 'text-green-600' : 
-                  scoreBreakdown.geoProtection.score > 5 ? 'text-yellow-600' : 'text-red-600'
-                }`}>
-                  {scoreBreakdown.geoProtection.score}/{scoreBreakdown.geoProtection.maxPossible}
+                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.geoProtection.score > 10 ? 'text-green-600' :
+                    scoreBreakdown.geoProtection.score > 5 ? 'text-yellow-600' : 'text-red-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.geoProtection.score}/{scoreBreakdown.geoProtection.maxPossible}
+                    </span>
+                    <Progress
+                      score={scoreBreakdown.geoProtection.score}
+                      max={scoreBreakdown.geoProtection.maxPossible}
+                      color={
+                        scoreBreakdown.geoProtection.score > 10 ? 'bg-green-500' :
+                        scoreBreakdown.geoProtection.score > 5 ? 'bg-yellow-500' : 'bg-red-500'
+                      }
+                    />
+                  </div>
                 </td>
               </tr>
               <tr className="bg-blue-50">
@@ -565,17 +657,30 @@ const FixedBeachView = ({
                   TOTAL SCORE
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap"></td>
-                <td className={`px-4 py-3 whitespace-nowrap text-sm font-bold text-right ${
-                  scoreBreakdown.total.score >= 85 ? 'text-green-600' :
-                  scoreBreakdown.total.score >= 70 ? 'text-yellow-600' :
-                  scoreBreakdown.total.score >= 50 ? 'text-orange-600' : 'text-red-600'
-                }`}>
-                  {scoreBreakdown.total.score}/{scoreBreakdown.total.maxPossible}
-                  {scoreBreakdown.total.rawScore > scoreBreakdown.total.maxPossible && (
-                    <span className="text-xs text-gray-500 ml-1">
-                      (raw {scoreBreakdown.total.rawScore})
+                <td className="px-4 py-3 whitespace-nowrap text-sm font-bold text-right">
+                  <div className={`flex flex-col items-end ${
+                    scoreBreakdown.total.score >= 85 ? 'text-green-600' :
+                    scoreBreakdown.total.score >= 70 ? 'text-yellow-600' :
+                    scoreBreakdown.total.score >= 50 ? 'text-orange-600' : 'text-red-600'
+                  }`}>
+                    <span>
+                      {scoreBreakdown.total.score}/{scoreBreakdown.total.maxPossible}
+                      {scoreBreakdown.total.rawScore > scoreBreakdown.total.maxPossible && (
+                        <span className="text-xs text-gray-500 ml-1">
+                          (raw {scoreBreakdown.total.rawScore})
+                        </span>
+                      )}
                     </span>
-                  )}
+                    <Progress
+                      score={scoreBreakdown.total.score}
+                      max={scoreBreakdown.total.maxPossible}
+                      color={
+                        scoreBreakdown.total.score >= 85 ? 'bg-green-500' :
+                        scoreBreakdown.total.score >= 70 ? 'bg-yellow-500' :
+                        scoreBreakdown.total.score >= 50 ? 'bg-orange-500' : 'bg-red-500'
+                      }
+                    />
+                  </div>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary
- add a progress bar helper to FixedBeachView
- show bars for each item in the score breakdown table
- add explanatory text describing the table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842e73ba0d8832295cf84e4c310a076