### PR TITLE
Auto-set time range to current hour

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,10 +10,15 @@ const App = () => {
   const [view, setView] = useState("dashboard");
   const [selectedBeach, setSelectedBeach] = useState(null);
   const [notification, setNotification] = useState(null);
-  const [timeRange, setTimeRange] = useState({
-    date: new Date().toISOString().split("T")[0],
-    startTime: "09:00",
-    endTime: "13:00",
+  const [timeRange, setTimeRange] = useState(() => {
+    const now = new Date();
+    const startHour = now.getHours();
+    const endHour = Math.min(startHour + 6, 23);
+    return {
+      date: now.toISOString().split("T")[0],
+      startTime: `${String(startHour).padStart(2, "0")}:00`,
+      endTime: `${String(endHour).padStart(2, "0")}:00`,
+    };
   });
   const [lastUpdated, setLastUpdated] = useState(null);
   const [showFAQ, setShowFAQ] = useState(false); // New state for FAQ visibility


### PR DESCRIPTION
## Summary
- use a function in `App.jsx` to calculate a default time range
- new time range spans from the user's current hour to six hours ahead

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846b51e391c83228b5650727ff7c5d3