### PR TITLE
Remove capped score note

### DIFF
--- a/src/FixedBeachView.jsx
+++ b/src/FixedBeachView.jsx
@@ -709,9 +709,6 @@ const FixedBeachView = ({
               </tr>
             </tbody>
           </table>
-          <p className="text-xs text-gray-500 mt-2 px-4">
-            All factors sum to 100 points. Scores above 100 are capped.
-          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- remove reference to capped scoring note in the Beach table view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684884abc0b08322ac8c6b37d94a4617