### PR TITLE
Add nearest beach geolocation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A web app for planning stand-up paddleboarding sessions at Greek beaches. It com
 - **Geographic protection scoring.** Custom GIS datasets of the Greek coastline and islands are used to analyse how sheltered each beach is from wind and waves.
 - **Paddle score.** All factors are combined into a 0–100 rating so you can easily compare spots. An FAQ explains how the score is calculated.
 - **Local storage.** Your beaches and preferred "home" beach are saved in the browser so they appear on your next visit.
-- **Locate nearest popular beach.** Use your browser's location to quickly add the closest suggested spot.
+- **Locate nearest recommended location.** Use your browser's location to quickly add the closest suggested spot. Works on desktop and iPhone browsers that support HTML5 geolocation.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A web app for planning stand-up paddleboarding sessions at Greek beaches. It com
 - **Geographic protection scoring.** Custom GIS datasets of the Greek coastline and islands are used to analyse how sheltered each beach is from wind and waves.
 - **Paddle score.** All factors are combined into a 0–100 rating so you can easily compare spots. An FAQ explains how the score is calculated.
 - **Local storage.** Your beaches and preferred "home" beach are saved in the browser so they appear on your next visit.
+- **Locate nearest popular beach.** Use your browser's location to quickly add the closest suggested spot.
 
 ## Development
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -136,7 +136,7 @@ const App = () => {
     }
   };
 
-  // Find and add the nearest popular beach using browser geolocation
+  // Find and add the nearest recommended spot using browser geolocation
   const handleFindNearest = () => {
     if (!navigator.geolocation) {
       toast.error("Geolocation not supported by your browser");
@@ -167,7 +167,7 @@ const App = () => {
           }
         }
         setLocating(false);
-        if (window.confirm(`Add ${nearest.name} to your beaches?`)) {
+        if (window.confirm(`Add ${nearest.name} to your locations?`)) {
           handleAddSuggested(nearest);
         }
       },
@@ -400,7 +400,7 @@ const App = () => {
                   className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
                   disabled={locating}
                 >
-                  {locating ? 'Finding nearest beach...' : 'Find Nearest Popular Beach'}
+                  {locating ? 'Finding nearest location...' : 'Find Nearest Recommended Spot'}
                 </button>
               </div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ const App = () => {
   });
   const [lastUpdated, setLastUpdated] = useState(null);
   const [showFAQ, setShowFAQ] = useState(false); // New state for FAQ visibility
+  const [locating, setLocating] = useState(false);
   
   
   // Format last updated time strings
@@ -133,6 +134,49 @@ const App = () => {
     } catch (error) {
       toast.error(error.message);
     }
+  };
+
+  // Find and add the nearest popular beach using browser geolocation
+  const handleFindNearest = () => {
+    if (!navigator.geolocation) {
+      toast.error("Geolocation not supported by your browser");
+      return;
+    }
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        const toRad = (deg) => deg * Math.PI / 180;
+        const distance = (lat1, lon1, lat2, lon2) => {
+          const R = 6371;
+          const dLat = toRad(lat2 - lat1);
+          const dLon = toRad(lon2 - lon1);
+          const a = Math.sin(dLat / 2) ** 2 +
+            Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+            Math.sin(dLon / 2) ** 2;
+          return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        };
+
+        let nearest = suggestedLocations[0];
+        let minDist = distance(latitude, longitude, nearest.latitude, nearest.longitude);
+        for (const loc of suggestedLocations.slice(1)) {
+          const d = distance(latitude, longitude, loc.latitude, loc.longitude);
+          if (d < minDist) {
+            minDist = d;
+            nearest = loc;
+          }
+        }
+        setLocating(false);
+        if (window.confirm(`Add ${nearest.name} to your beaches?`)) {
+          handleAddSuggested(nearest);
+        }
+      },
+      (err) => {
+        console.error('Geolocation error', err);
+        toast.error('Unable to retrieve your location');
+        setLocating(false);
+      }
+    );
   };
   
   // Handle delete beach
@@ -349,6 +393,15 @@ const App = () => {
                     </p>
                   )}
                 </div>
+              </div>
+              <div className="mb-8">
+                <button
+                  onClick={handleFindNearest}
+                  className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
+                  disabled={locating}
+                >
+                  {locating ? 'Finding nearest beach...' : 'Find Nearest Popular Beach'}
+                </button>
               </div>
 
               <div className="mb-6">


### PR DESCRIPTION
## Summary
- add geolocation button to find closest recommended beach
- implement `handleFindNearest` in `App.jsx`
- document new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684886458e88832283d3e9c2e1602060